### PR TITLE
Fix for dependency tests and scss files

### DIFF
--- a/src/play/modules/sass/Engine.java
+++ b/src/play/modules/sass/Engine.java
@@ -158,7 +158,10 @@ public class Engine {
                     for (String path : sassPaths) {
                         File depSass = new File(path + "/" + fileName);
                         if (!depSass.exists()) {
-                            depSass = new File(depSass.getParentFile() + "/_" + depSass.getName() + ".sass");
+                            depSass = new File(path + "/_" + fileName + ".sass");
+                        }
+                        if (!depSass.exists()) {
+                            depSass = new File(path + "/_" + fileName + ".scss");
                         }
                         if (depSass.exists()) {
                             findDependencies(depSass, all);


### PR DESCRIPTION
The current dependency change checking code will only look for `.sass` files, not `.scss` even though the main processor works fine with `.scss`.

With this change `DEV` mode will correctly pick up changes to files included without an extension (`include "base"`) which actually refer to a `.scss` file.
